### PR TITLE
Update RT-DETR confidence threshold dynamically

### DIFF
--- a/isaac_ros_rtdetr/include/isaac_ros_rtdetr/rtdetr_decoder_node.hpp
+++ b/isaac_ros_rtdetr/include/isaac_ros_rtdetr/rtdetr_decoder_node.hpp
@@ -20,8 +20,10 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "rclcpp/rclcpp.hpp"
+#include "rcl_interfaces/msg/set_parameters_result.hpp"
 
 #include "isaac_ros_common/qos.hpp"
 #include "isaac_ros_managed_nitros/managed_nitros_subscriber.hpp"
@@ -45,6 +47,9 @@ public:
 private:
   void InputCallback(const nvidia::isaac_ros::nitros::NitrosTensorListView & msg);
 
+  rcl_interfaces::msg::SetParametersResult ParametersCallback(
+    const std::vector<rclcpp::Parameter> & parameters);
+
   // QOS settings
   rclcpp::QoS input_qos_;
   rclcpp::QoS output_qos_;
@@ -60,6 +65,7 @@ private:
   std::string boxes_tensor_name_{};
   std::string scores_tensor_name_{};
   double confidence_threshold_{};
+  rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr parameter_callback_handle_;
   cudaStream_t stream_;
 };
 

--- a/isaac_ros_rtdetr/src/rtdetr_decoder_node.cpp
+++ b/isaac_ros_rtdetr/src/rtdetr_decoder_node.cpp
@@ -68,11 +68,32 @@ RtDetrDecoderNode::RtDetrDecoderNode(const rclcpp::NodeOptions options)
   confidence_threshold_{declare_parameter<double>("confidence_threshold", 0.9)}
 {
   cudaStreamCreate(&stream_);
+
+  parameter_callback_handle_ = add_on_set_parameters_callback(
+    std::bind(
+      &RtDetrDecoderNode::ParametersCallback,
+      this,
+      std::placeholders::_1));
 }
 
 RtDetrDecoderNode::~RtDetrDecoderNode()
 {
   cudaStreamDestroy(stream_);
+}
+
+rcl_interfaces::msg::SetParametersResult RtDetrDecoderNode::ParametersCallback(
+  const std::vector<rclcpp::Parameter> & parameters)
+{
+  rcl_interfaces::msg::SetParametersResult result;
+  result.successful = true;
+
+  for (const auto &parameter : parameters) {
+    if (parameter.get_name() == "confidence_threshold") {
+      confidence_threshold_ = parameter.as_double();
+    }
+  }
+
+  return result;
 }
 
 void RtDetrDecoderNode::InputCallback(


### PR DESCRIPTION
@jaiveersinghNV @kajananchinniahNV 

## Description

This PR updates the RT-DETR decoder so runtime changes to the `confidence_threshold` parameter are applied without restarting the node.

Previously, `confidence_threshold` was declared and copied into the `confidence_threshold_` member variable during node construction. As a result, running:

```bash
ros2 param set /rtdetr_decoder confidence_threshold 0.75
```
updated the ROS parameter value, but the decoder continued using the original startup value inside InputCallback().

This change adds a parameter callback that updates confidence_threshold_ when the parameter is changed.

## Testing

Built the package, verified the parameter can be changed at runtime and confirmed that detections update without restarting the node.

results on the examples with the low threshold `ros2 param set /rtdetr_decoder confidence_threshold 0.1`

<img width="765" height="767" alt="image" src="https://github.com/user-attachments/assets/eb8d5f9a-78f7-4e22-b77c-2971ac9d782f" />
